### PR TITLE
Change number of digits to match gauge max value

### DIFF
--- a/speedometer.js
+++ b/speedometer.js
@@ -144,7 +144,7 @@ function Speedometer(Element) {
       this.drawHand ();
 
       if (Display)
-        Display.drawNumber (CurValue, 3, Position.h / 1.2, Size / 9);
+        Display.drawNumber (CurValue, MaxValue.toString().length, Position.h / 1.2, Size / 9);
     }
   }
 
@@ -178,7 +178,7 @@ function Speedometer(Element) {
     if (Display)
     {
       Display.clear ();
-      Display.drawNumber (CurValue, 3, Position.h / 1.2, Size / 9);
+      Display.drawNumber (CurValue, MaxValue.toString().length, Position.h / 1.2, Size / 9);
     }
 
     return CurValue;


### PR DESCRIPTION
Currently, the number of digits is hard-coded to 3. This isn't suitable when the maximum gauge value needs more than three digits.
With no option to configure the number of digits, this should offer better default behaviour
